### PR TITLE
Fix name of `is_wiki_doc` variable

### DIFF
--- a/bpdw.php
+++ b/bpdw.php
@@ -99,7 +99,7 @@ function bpdw_is_wiki_doc( $doc_id ) {
 	if ( ! empty( $cached_is_wiki_term ) ) {
 		$cached_term = array_pop( $cached_is_wiki_term );
 		if ( 1 == $cached_term->slug ) {
-			$is_wiki_term = true;
+			$is_wiki_doc = true;
 		}
 	}
 


### PR DESCRIPTION
Fixes the return value of the `bpdw_is_wiki_doc` function. Looks like a typo or copypasta to me :-)